### PR TITLE
Fix digest normalization for Markdown headings

### DIFF
--- a/scripts/run_digest_job.py
+++ b/scripts/run_digest_job.py
@@ -474,8 +474,9 @@ def main() -> None:
         if not markdown.strip():  # 空のMarkdownが返された場合のフォールバック
             print("[info] LLM returned empty narrative, using action-first fallback.")
             markdown = "### セール/エアドロ速報（フォールバック）\n\n（情報なし）"
-        if not quota_notice:
-            markdown = normalize_digest_markdown(markdown)
+
+    if not quota_notice:
+        markdown = normalize_digest_markdown(markdown)
     post_markdown(discord_webhook, markdown)
 
     # 旧スキーマに依存するため状態保存は一旦無効化

--- a/src/delivery/normalize.py
+++ b/src/delivery/normalize.py
@@ -91,15 +91,16 @@ def normalize_digest_markdown(markdown: str) -> str:
     text = markdown or ""
     if not text.strip():
         return text
-    stripped_text = text.lstrip()
-    if stripped_text.startswith('### '):
-        return text.strip()
     # always reflow to deduplicate topics, even if markdown already uses headings
     lines = [line.rstrip() for line in text.splitlines() if not line.strip().startswith('```')]
     if not lines:
         return text
 
     header_line = lines[0].strip()
+    if header_line.startswith('### '):
+        header_line = header_line[4:].strip()
+    elif header_line.startswith('## '):
+        header_line = header_line[3:].strip()
     content_lines = lines[1:]
 
     section_topics: Dict[str, List[Dict[str, str]]] = {}


### PR DESCRIPTION
## Summary
- ensure digest normalization runs even when Gemini emits ### headers
- strip leading ###/## markers from the header before rebuilding sections to prevent duplicates

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ee4d23a4f08325a7e561d4e081a0c9